### PR TITLE
feat: publish posts and notes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -60,8 +60,12 @@ module.exports = function (config) {
       .slice(0, site.maxPostsPerPage);
   });
 
+  const liveShorts = (post) => post.date <= now && !post.data.draft;
+
   config.addCollection('shorts', (collection) => {
-    return [...collection.getFilteredByGlob('./src/shorts/*.md')].reverse();
+    return [
+      ...collection.getFilteredByGlob('./src/shorts/*.md').filter(liveShorts),
+    ].reverse();
   });
 
   // Plugins

--- a/_lambda/deploy-succeeded.js
+++ b/_lambda/deploy-succeeded.js
@@ -1,107 +1,17 @@
 const fetch = require('node-fetch');
-const Twitter = require('twitter');
-const Entities = require('html-entities').AllHtmlEntities;
+const { URL } = process.env;
 
-require('dotenv').config;
+const POSTS = `${URL}/.netlify/functions/publish-posts`;
+const NOTES = `${URL}/.netlify/functions/publish-notes`;
 
-const FEED = 'https://danmatthew.co.uk/shorts/feed.json';
-
-const twitter = new Twitter({
-  consumer_key: process.env.TWITTER_CONSUMER_KEY,
-  consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
-  access_token_key: process.env.TWITTER_ACCESS_TOKEN_KEY,
-  access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
-});
-
-const handleError = (error) => {
-  console.error(error);
-  const msg = Array.isArray(error) ? error[0].message : error.message;
+exports.handler = async (event, context) => {
+  const triggerPosts = await fetch(POSTS);
+  const triggerNotes = await fetch(NOTES);
 
   return {
-    statusCode: 422,
-    body: String(msg),
+    statusCode: 200,
+    body: JSON.stringify({
+      data: context,
+    }),
   };
-};
-
-const status = (code, message) => {
-  console.log(message);
-
-  return {
-    statusCode: code,
-    body: message,
-  };
-};
-
-const processNotes = async (notes) => {
-  const postItems = notes.items;
-
-  if (!postItems.length) {
-    return status(404, 'No notes to process');
-  }
-
-  const latestNote = postItems[0];
-
-  if (!latestNote.syndicate) {
-    return status(400, 'Latest note has disabled syndication. No action taken');
-  }
-
-  try {
-    const query = await twitter.get('search/tweets', { q: latestNote.url });
-
-    if (query.statuses && query.statuses.length === 0) {
-      return publishNote(latestNote);
-    } else {
-      return status(400, 'Latest note was already syndicated. No action taken');
-    }
-  } catch (error) {
-    return handleError(error);
-  }
-};
-
-const prepareStatusText = (note) => {
-  const maxLength = 280 - 3 - 1 - 23 - 20;
-  const entities = new Entities();
-
-  let text = note.content_html.trim().replace(/<[^>]+>/g, '');
-  text = entities.decode(text);
-
-  if (text.length > maxLength) {
-    text = text.substring(0, maxLength) + '…';
-  }
-
-  text += ' ' + note.url;
-
-  if (note.link && note.link.length) {
-    text += ' ' + note.link;
-  }
-
-  return text;
-};
-
-const publishNote = async (note) => {
-  try {
-    const statusText = prepareStatusText(note);
-
-    const tweet = await twitter.post('statuses/update', {
-      status: statusText,
-    });
-
-    if (tweet) {
-      return status(
-        200,
-        `Note ${note.date_published} successfully posted to Twitter`
-      );
-    } else {
-      return status(422, 'Error posting to Twitter API');
-    }
-  } catch (error) {
-    return handleError(error);
-  }
-};
-
-exports.handler = async () => {
-  return fetch(FEED)
-    .then((response) => response.json())
-    .then(processNotes)
-    .catch(handleError);
 };

--- a/_lambda/publish-notes.js
+++ b/_lambda/publish-notes.js
@@ -1,0 +1,107 @@
+const fetch = require('node-fetch');
+const Twitter = require('twitter');
+const Entities = require('html-entities').AllHtmlEntities;
+
+require('dotenv').config;
+
+const FEED = 'https://danmatthew.co.uk/feed.json';
+
+const twitter = new Twitter({
+  consumer_key: process.env.TWITTER_CONSUMER_KEY,
+  consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
+  access_token_key: process.env.TWITTER_ACCESS_TOKEN_KEY,
+  access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
+});
+
+const handleError = (error) => {
+  console.error(error);
+  const msg = Array.isArray(error) ? error[0].message : error.message;
+
+  return {
+    statusCode: 422,
+    body: String(msg),
+  };
+};
+
+const status = (code, message) => {
+  console.log(message);
+
+  return {
+    statusCode: code,
+    body: message,
+  };
+};
+
+const processNotes = async (notes) => {
+  const postItems = notes.items;
+
+  if (!postItems.length) {
+    return status(404, 'No notes to process');
+  }
+
+  const latestNote = postItems[0];
+
+  if (!latestNote.syndicate) {
+    return status(400, 'Latest note has disabled syndication. No action taken');
+  }
+
+  try {
+    const query = await twitter.get('search/tweets', { q: latestNote.url });
+
+    if (query.statuses && query.statuses.length === 0) {
+      return publishNote(latestNote);
+    } else {
+      return status(400, 'Latest note was already syndicated. No action taken');
+    }
+  } catch (error) {
+    return handleError(error);
+  }
+};
+
+const prepareStatusText = (note) => {
+  const maxLength = 280 - 3 - 1 - 23 - 20;
+  const entities = new Entities();
+
+  let text = note.content_html.trim().replace(/<[^>]+>/g, '');
+  text = entities.decode(text);
+
+  if (text.length > maxLength) {
+    text = text.substring(0, maxLength) + '…';
+  }
+
+  text += ' ' + note.url;
+
+  if (note.link && note.link.length) {
+    text += ' ' + note.link;
+  }
+
+  return text;
+};
+
+const publishNote = async (note) => {
+  try {
+    const statusText = prepareStatusText(note);
+
+    const tweet = await twitter.post('statuses/update', {
+      status: statusText,
+    });
+
+    if (tweet) {
+      return status(
+        200,
+        `Note ${note.date_published} successfully posted to Twitter`
+      );
+    } else {
+      return status(422, 'Error posting to Twitter API');
+    }
+  } catch (error) {
+    return handleError(error);
+  }
+};
+
+exports.handler = async () => {
+  return fetch(FEED)
+    .then((response) => response.json())
+    .then(processNotes)
+    .catch(handleError);
+};

--- a/_lambda/publish-posts.js
+++ b/_lambda/publish-posts.js
@@ -1,0 +1,107 @@
+const fetch = require('node-fetch');
+const Twitter = require('twitter');
+const Entities = require('html-entities').AllHtmlEntities;
+
+require('dotenv').config;
+
+const FEED = 'https://danmatthew.co.uk/feed.json';
+
+const twitter = new Twitter({
+  consumer_key: process.env.TWITTER_CONSUMER_KEY,
+  consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
+  access_token_key: process.env.TWITTER_ACCESS_TOKEN_KEY,
+  access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
+});
+
+const handleError = (error) => {
+  console.error(error);
+  const msg = Array.isArray(error) ? error[0].message : error.message;
+
+  return {
+    statusCode: 422,
+    body: String(msg),
+  };
+};
+
+const status = (code, message) => {
+  console.log(message);
+
+  return {
+    statusCode: code,
+    body: message,
+  };
+};
+
+const processNotes = async (notes) => {
+  const postItems = notes.items;
+
+  if (!postItems.length) {
+    return status(404, 'No posts to process');
+  }
+
+  const latestNote = postItems[0];
+
+  if (!latestNote.syndicate) {
+    return status(400, 'Latest post has disabled syndication. No action taken');
+  }
+
+  try {
+    const query = await twitter.get('search/tweets', { q: latestNote.url });
+
+    if (query.statuses && query.statuses.length === 0) {
+      return publishNote(latestNote);
+    } else {
+      return status(400, 'Latest post was already syndicated. No action taken');
+    }
+  } catch (error) {
+    return handleError(error);
+  }
+};
+
+const prepareStatusText = (note) => {
+  const maxLength = 280 - 3 - 1 - 23 - 20;
+  const entities = new Entities();
+
+  let text = note.content_html.trim().replace(/<[^>]+>/g, '');
+  text = entities.decode(text);
+
+  if (text.length > maxLength) {
+    text = text.substring(0, maxLength) + '…';
+  }
+
+  text += ' ' + note.url;
+
+  if (note.link && note.link.length) {
+    text += ' ' + note.link;
+  }
+
+  return text;
+};
+
+const publishNote = async (note) => {
+  try {
+    const statusText = prepareStatusText(note);
+
+    const tweet = await twitter.post('statuses/update', {
+      status: statusText,
+    });
+
+    if (tweet) {
+      return status(
+        200,
+        `Post ${note.date_published} successfully posted to Twitter`
+      );
+    } else {
+      return status(422, 'Error posting to Twitter API');
+    }
+  } catch (error) {
+    return handleError(error);
+  }
+};
+
+exports.handler = async () => {
+  return fetch(FEED)
+    .then((response) => response.json())
+    .then(processNotes)
+    .catch(handleError);
+};

--- a/src/shorts/circle-ci-node-browsers.md
+++ b/src/shorts/circle-ci-node-browsers.md
@@ -1,0 +1,7 @@
+---
+title: CircleCI Node Images with Browsers
+link: https://circleci.com/docs/2.0/docker-image-tags.json
+date: '2020-07-27'
+---
+
+Building a Node project with Circle and want access to browser binaries? The default `circleci/node` image doesn't come with them installed, which threw a spanner in the works when attempting to run some tests. Circle maintain an exhaustive list of images one can use: any Node version appended with `-browsers` will come installed with Chrome, Firefox, OpenJDK v11, and Geckodriver.


### PR DESCRIPTION
- `deploy-succeeded` triggers two other serverless functions