### PR TITLE
Add Playwright smoke test

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "format:eslint": "eslint --ext .js,.html . --fix --ignore-path .gitignore",
     "format:prettier": "prettier \"**/*.js\" --write",
     "test": "cypress run --spec \"cypress/integration/home_page.spec.js\"",
+    "test:playwright": "playwright test",
     "release": "npx standard-version && git push --follow-tags"
   },
   "repository": {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+
+test('homepage renders h1', async ({ page }) => {
+  await page.goto(baseURL);
+  await expect(page.locator('h1').first()).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add `tests/smoke.spec.ts` for Playwright smoke test
- expose a `test:playwright` npm script

## Testing
- `npm run test:playwright -- --list` *(fails: playwright command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e803bf6e883298e76af4ae6dc9cf5