### PR TITLE
Add automated accessibility testing with axe-core

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,57 @@
+name: Accessibility (axe-core)
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'astro.config.mjs'
+      - 'netlify.toml'
+
+jobs:
+  axe:
+    name: axe-core audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build site
+        run: pnpm build:ci
+
+      - name: Start preview server
+        run: pnpm astro preview --port 4321 &
+
+      - name: Wait for server
+        run: npx wait-on http://localhost:4321 --timeout 30000
+
+      - name: Run axe-core audit
+        run: |
+          npx @axe-core/cli \
+            http://localhost:4321/ \
+            http://localhost:4321/about \
+            http://localhost:4321/work \
+            http://localhost:4321/articles \
+            http://localhost:4321/notes \
+            http://localhost:4321/resume \
+            --exit \
+            --reporter json \
+            --save axe-results.json
+
+      - name: Upload axe results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: axe-results
+          path: axe-results.json

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dev": "tinacms dev -c \"astro dev\"",
     "start": "astro start",
     "build": "tinacms build && astro build",
+    "build:ci": "astro build",
     "preview": "astro preview",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:eslint": "eslint --ext .js,.html . --ignore-path .gitignore",


### PR DESCRIPTION
## Summary
This PR introduces automated accessibility testing to the CI/CD pipeline using axe-core, ensuring that accessibility standards are maintained across the site.

## Key Changes
- **New GitHub Actions workflow** (`.github/workflows/accessibility.yml`):
  - Runs on pull requests that modify source files, public assets, or configuration files
  - Builds the site and starts a preview server
  - Executes axe-core accessibility audit against key pages (home, about, work, articles, notes, resume)
  - Uploads audit results as artifacts for review
  
- **New npm script** (`build:ci` in `package.json`):
  - Dedicated build script for CI environments that skips TinaCMS build step
  - Allows faster builds in automated workflows

## Implementation Details
- The workflow uses `axe-core/cli` to perform automated accessibility scans
- Results are saved in JSON format and uploaded as GitHub artifacts for analysis
- The workflow runs on `ubuntu-latest` with Node 20 and pnpm 10
- Scans are performed on the built preview server to test the production-ready output
- The workflow uses `--exit` flag to fail the build if accessibility violations are found

https://claude.ai/code/session_01Bv57XAkjpTA7ybydBnSVrP