### PR TITLE
Add Mastodon syndication support via Bridgy

### DIFF
--- a/.github/workflows/syndicate-to-mastodon.yml
+++ b/.github/workflows/syndicate-to-mastodon.yml
@@ -1,0 +1,61 @@
+name: Syndicate to Mastodon via Bridgy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/content/posts/**"
+
+jobs:
+  syndicate:
+    name: Send webmentions to Bridgy Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Find added or modified posts
+        id: changed-posts
+        run: |
+          git diff --name-only --diff-filter=AM HEAD~1 HEAD -- src/content/posts/ \
+            | grep -E '\.(md|mdx)$' > changed_posts.txt || true
+          echo "Changed posts:"
+          cat changed_posts.txt
+
+      - name: Wait for Netlify deploy
+        run: |
+          echo "Waiting for site to reflect the latest deploy..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://danmatthew.co.uk/)
+            if [ "$STATUS" = "200" ]; then
+              echo "Site is live (attempt $i)"
+              # Extra buffer to ensure new content is deployed
+              sleep 30
+              break
+            fi
+            echo "Not ready yet (attempt $i, status $STATUS), retrying in 10s..."
+            sleep 10
+          done
+
+      - name: Send webmentions to Bridgy
+        run: |
+          if [ ! -s changed_posts.txt ]; then
+            echo "No changed posts to syndicate."
+            exit 0
+          fi
+          while IFS= read -r post_file; do
+            if [ -z "$post_file" ]; then continue; fi
+            # Strip directory prefix and extension to get the slug
+            filename=$(basename "$post_file")
+            slug="${filename%.mdx}"
+            slug="${slug%.md}"
+            post_url="https://danmatthew.co.uk/notes/${slug}/"
+            echo "Sending webmention for: $post_url"
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X POST https://brid.gy/publish/webmention \
+              --data-urlencode "source=${post_url}" \
+              --data-urlencode "target=https://brid.gy/publish/mastodon")
+            echo "Bridgy responded with HTTP $HTTP_STATUS for $post_url"
+          done < changed_posts.txt

--- a/src/content.config.js
+++ b/src/content.config.js
@@ -30,6 +30,7 @@ export const collections = {
         .transform((str) => (str ? new Date(str) : undefined)),
       published: z.boolean().default(true).optional(),
       evergreen: z.boolean().optional(),
+      syndicationUrl: z.string().url().optional(),
     }),
   }),
   articles: defineCollection({

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -77,6 +77,8 @@ const { title, description, modifier } = Astro.props;
     <meta name="theme-color" content="hsl(0, 0%, 99%)" />
     <link rel="alternate" type="application/rss+xml" title="Dan Matthew" href="/feed.xml" />
     <link rel="alternate" type="application/feed+json" title="Dan Matthew" href="/feed.json" />
+    <link rel="webmention" href="https://webmention.io/danmatthew.co.uk/webmention" />
+    <link rel="pingback" href="https://webmention.io/xmlrpc" />
   </head>
   <body>
     <Nav />

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -38,20 +38,29 @@ export async function getStaticPaths() {
 const { entry, prevPost, nextPost } = Astro.props;
 
 const { Content } = await render(entry);
+
+const canonicalUrl = new URL(`/notes/${entry.id}/`, Astro.site).toString();
+const { syndicationUrl } = entry.data;
 ---
 
 <BaseLayout title={`${entry.data.title}`}>
-  <article>
+  <article class="h-entry">
     <Hero title={entry.data.title}>
       <div slot="header-extras">
         <div class="meta">
-          <time datetime={entry.data.publishedDate.toISOString()}>
+          <time class="dt-published" datetime={entry.data.publishedDate.toISOString()}>
             {entry.data.publishedDate.toLocaleDateString("en-GB")}
           </time>
         </div>
       </div>
     </Hero>
-    <section class="flow">
+    <data class="p-name" value={entry.data.title} hidden></data>
+    <a class="u-url" href={canonicalUrl} hidden></a>
+    {syndicationUrl
+      ? <a class="u-syndication" href={syndicationUrl} rel="syndication">View on Mastodon</a>
+      : <a class="u-syndication" href="https://brid.gy/publish/mastodon" rel="syndication" hidden></a>
+    }
+    <section class="e-content flow">
       <Content />
     </section>
   </article>


### PR DESCRIPTION
## Summary
This PR adds support for syndicating blog posts to Mastodon using Bridgy's webmention publishing service. It includes a new GitHub Actions workflow to automatically send webmentions when posts are published, microformat markup for proper syndication, and webmention endpoint configuration.

## Key Changes

- **New GitHub Actions Workflow** (`syndicate-to-mastodon.yml`): Automatically detects new or modified posts in the `src/content/posts/` directory, waits for the Netlify deployment to be live, and sends webmentions to Bridgy Publish for Mastodon syndication.

- **Microformat Markup** (`src/pages/notes/[...slug].astro`): Added h-entry microformat classes to the post template:
  - `h-entry` on the article element
  - `dt-published` on the publication date
  - `p-name` for the post title
  - `u-url` for the canonical URL
  - `u-syndication` for syndication links
  - `e-content` for the post content

- **Webmention Configuration** (`src/layouts/BaseLayout.astro`): Added webmention and pingback endpoint links to enable receiving webmentions from other sites.

- **Content Schema Update** (`src/content.config.js`): Added optional `syndicationUrl` field to post frontmatter to track syndicated copies of posts.

## Implementation Details

The workflow waits up to 5 minutes for the site to be deployed before sending webmentions, ensuring the new content is live and discoverable. Posts are identified by their filename slug, and the syndication URL is constructed as `https://danmatthew.co.uk/notes/{slug}/`. The microformat markup enables Bridgy to properly parse and syndicate the content to Mastodon.

https://claude.ai/code/session_011QXNRDSYqNMS9wQQTTtJHx